### PR TITLE
feat: verify location status

### DIFF
--- a/.devo/provisioning/infrastructure/datasources/mongo/seeder-mongo.sh
+++ b/.devo/provisioning/infrastructure/datasources/mongo/seeder-mongo.sh
@@ -50,6 +50,7 @@ const locs = [{
         name: 'Mrs. Manuel Bergnaum',
         address: 'Direct',
         country: 'Jeremy Rowe',
+        status: 'complete',
         coordinates: {
           type: 'Point',
           coordinates: [
@@ -65,6 +66,7 @@ const locs = [{
         name: 'Jeanette Jerde',
         address: 'Keyboard',
         country: 'Ruth Nicolas',
+        status: 'incomplete',
         coordinates: {
           type: 'Point',
           coordinates: [
@@ -80,6 +82,7 @@ const locs = [{
         name: 'Sergio Pagac',
         address: 'synthesizing',
         country: 'Tommy Kuvalis',
+        status: 'complete',
         coordinates: {
           type: 'Point',
           coordinates: [
@@ -95,6 +98,7 @@ const locs = [{
         name: 'Esther Bashirian',
         address: 'Florida',
         country: 'Ricky Graham',
+        status: 'complete',
         coordinates: {
           type: 'Point',
           coordinates: [
@@ -110,6 +114,7 @@ const locs = [{
         name: 'Elias Haag MD',
         address: 'Dollar',
         country: 'Rochelle Lockman',
+        status: 'incomplete',
         coordinates: {
           type: 'Point',
           coordinates: [

--- a/apps/assistance-centers/src/Locations/application/queries/FindLocationsQuery/FindLocationsQueryHandler.ts
+++ b/apps/assistance-centers/src/Locations/application/queries/FindLocationsQuery/FindLocationsQueryHandler.ts
@@ -8,6 +8,7 @@ import { Nullable } from '@turnly/common'
 import { IQueryHandler, QueryBuilder, QueryHandler } from '@turnly/shared'
 import { ILocationsReadableRepo } from 'Locations/domain/contracts/ILocationsRepo'
 import { Location } from 'Locations/domain/entities/Location'
+import { LocationStatus } from 'Locations/domain/enums/LocationStatus'
 
 import { FindLocationsQuery } from './FindLocationsQuery'
 
@@ -30,6 +31,7 @@ export class FindLocationsQueryHandler
   }: FindLocationsQuery) {
     const query = new QueryBuilder<Location>()
       .equal('organizationId', organizationId)
+      .equal('status', LocationStatus.COMPLETE)
       .orderByAlphabetical(['name'])
 
     if (country) query.equal('country', country)
@@ -37,7 +39,7 @@ export class FindLocationsQueryHandler
     if (lat && lng) query.orderByGeo('coordinates', { lat, lng })
 
     /**
-     * @todo Implement location status filter
+     * @todo Implement location status filter-- (Testing it)
      * @todo Add filters for open locations (Schedules and Holidays)
      */
 

--- a/apps/assistance-centers/src/Locations/domain/entities/Location.ts
+++ b/apps/assistance-centers/src/Locations/domain/entities/Location.ts
@@ -7,6 +7,7 @@
 import { Guid, Identifier } from '@turnly/common'
 import { AggregateRoot, EntityAttributes } from '@turnly/shared'
 
+import { LocationStatus } from '../enums/LocationStatus'
 import { LocationCreatedEvent } from '../events/LocationCreatedEvent'
 
 /**
@@ -45,6 +46,13 @@ export class Location extends AggregateRoot {
      * @description The country of the Location.
      */
     private country: string,
+
+    /**
+     * Status
+     *
+     * @description The status of the Location.
+     */
+    private status: LocationStatus = LocationStatus.INCOMPLETE,
 
     /**
      * Coordinates
@@ -86,6 +94,7 @@ export class Location extends AggregateRoot {
       attributes.name,
       attributes.address,
       attributes.country,
+      attributes.status,
       attributes.coordinates,
       attributes.stopServingBeforeInMinutes,
       attributes.organizationId
@@ -107,6 +116,7 @@ export class Location extends AggregateRoot {
       attributes.name,
       attributes.address,
       attributes.country,
+      attributes.status,
       attributes.coordinates,
       attributes.stopServingBeforeInMinutes,
       attributes.organizationId
@@ -124,6 +134,7 @@ export class Location extends AggregateRoot {
       name: this.name,
       address: this.address,
       country: this.country,
+      status: this.status,
       coordinates: this.coordinates,
       organizationId: this.organizationId,
       stopServingBeforeInMinutes: this.stopServingBeforeInMinutes,

--- a/apps/assistance-centers/src/Locations/domain/enums/LocationStatus.ts
+++ b/apps/assistance-centers/src/Locations/domain/enums/LocationStatus.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+export enum LocationStatus {
+  /**
+   * Complete status
+   *
+   * @description Use it when a location is ready to serve.
+   */
+  COMPLETE = 'complete',
+
+  /**
+   * Imcomplete status
+   *
+   * @description Use it when the location has been Imcomplete.
+   */
+  INCOMPLETE = 'incomplete',
+}

--- a/apps/assistance-centers/src/Locations/infrastructure/persistence/mongo/models/LocationModel.ts
+++ b/apps/assistance-centers/src/Locations/infrastructure/persistence/mongo/models/LocationModel.ts
@@ -6,6 +6,7 @@
  */
 import { EntityAttributes, timestamps } from '@turnly/shared'
 import { Location } from 'Locations/domain/entities/Location'
+import { LocationStatus } from 'Locations/domain/enums/LocationStatus'
 import mongoose, { Document, Model, Schema } from 'mongoose'
 
 export interface ILocationDocument
@@ -37,6 +38,11 @@ const schema = new Schema<ILocationDocument>(
     },
     country: {
       type: String,
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: LocationStatus,
       required: true,
     },
     coordinates: {

--- a/apps/assistance-centers/tests/unit/Locations/domain/Location.test.ts
+++ b/apps/assistance-centers/tests/unit/Locations/domain/Location.test.ts
@@ -13,6 +13,7 @@ describe('locations > domain > validates the min behavior in the life-cycle of a
       'id',
       'name',
       'address',
+      'status',
       'coordinates',
       'country',
       'stopServingBeforeInMinutes',

--- a/apps/assistance-centers/tests/unit/Locations/domain/LocationMother.ts
+++ b/apps/assistance-centers/tests/unit/Locations/domain/LocationMother.ts
@@ -6,6 +6,7 @@
  */
 import { Guid } from '@turnly/common'
 import { ObjectMother } from '@turnly/testing'
+import { LocationStatus } from 'Locations/domain/enums/LocationStatus'
 
 import { LocationByIdQuery } from '../../../../src/Locations/application/queries/LocationByIdQuery'
 import { Location } from '../../../../src/Locations/domain/entities/Location'
@@ -14,6 +15,7 @@ export class LocationMother {
   static create(
     name: string = ObjectMother.names(),
     address: string = ObjectMother.word(),
+    status: LocationStatus = LocationStatus.COMPLETE,
     coordinates = ObjectMother.coords(),
     country: string = ObjectMother.names(),
     stopServingBeforeInMinutes: number = ObjectMother.integer(2),
@@ -23,6 +25,7 @@ export class LocationMother {
       organizationId,
       name,
       address,
+      status,
       coordinates,
       stopServingBeforeInMinutes,
       country,


### PR DESCRIPTION
## Pull Request Overview

#### What does it do?

It adds the status attribute to the location entity and model, adapts the tests to the new entity and adds the new attribute to the seeder of assistance-centers db.

#### Why is it needed?

To filter the data in the find location query, so the incomplete locations doesn't appear in the result data.

#### How to test it?

Start the assistance-centers service and use the find locations endpoint. It should bring the locations with a complete status.
<!-- *Provide information about the environment and the path to verify the behavior* -->

`I agree`

Before asking for review I...

- [x] Used this first label: `🕐 Peer Review Pending`
- [x] Have added all relevant information about my changes in this PR
- [x] Have performed a self-review of my own code
- [x] Have made sure my code follows the project's style guidelines
- [x] Have checked my code and corrected any misspellings
- [x] Have made sure my changes generate no new warnings

/cc @efraa