### PR TITLE
feat(realtime-api): add agents tickets updates event to helpdesk

### DIFF
--- a/apps/realtime-api/src/broadcasting/broadcastable.ts
+++ b/apps/realtime-api/src/broadcasting/broadcastable.ts
@@ -57,5 +57,11 @@ export const broadcastable = {
     BroadcastableEvents.TICKET_UNASSIGNED,
     BroadcastableEvents.TICKET_REASSIGNED,
   ],
-  helpdesk: [BroadcastableEvents.TICKET_CREATED],
+  helpdesk: [
+    /**
+     * Ticket events
+     */
+    BroadcastableEvents.TICKET_CREATED,
+    BroadcastableEvents.TICKET_ANNOUNCED,
+  ],
 }

--- a/apps/realtime-api/src/broadcasting/realtimeEvents.ts
+++ b/apps/realtime-api/src/broadcasting/realtimeEvents.ts
@@ -15,6 +15,7 @@ export enum RealtimeEvents {
    * Ticket events
    */
   TICKET_BEFORE_YOURS_UPDATED = 'ticket.before-yours.updated',
+  AGENTS_TICKETS_UPDATES = 'agents.tickets.updates',
 
   /**
    * Global events

--- a/apps/realtime-api/src/channels/helpdesk/handlers/RealtimeForAgentsTicketsHandler.ts
+++ b/apps/realtime-api/src/channels/helpdesk/handlers/RealtimeForAgentsTicketsHandler.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+import { Guid } from '@turnly/common'
+import { AbstractRealtimeHandler, IRealtimeChannel } from '@turnly/realtime'
+import { Event, EventPayload, EventType } from '@turnly/shared'
+import { BroadcastableEvents } from 'broadcasting/broadcastableEvents'
+import { RealtimeEvents } from 'broadcasting/realtimeEvents'
+
+interface Payload extends EventPayload {
+  serviceId: Guid
+  customerId: Guid
+  locationId: Guid
+  ticketId: Guid
+  serviceName: string
+}
+
+export class RealtimeForAgentsTicketsHandler extends AbstractRealtimeHandler<
+  Event<Payload>
+> {
+  public constructor() {
+    super(RealtimeForAgentsTicketsHandler.getEvents())
+  }
+
+  public handle(event: Event<Payload>, channel: IRealtimeChannel): void {
+    const payload: Payload = {
+      ticketId: event.payload.ticketId,
+      locationId: event.payload.locationId,
+      serviceId: event.payload.serviceId,
+      customerId: event.payload.customerId,
+      serviceName: event.payload.serviceName,
+      organizationId: event.payload.organizationId,
+    }
+
+    channel.to(payload.locationId).emit(
+      RealtimeEvents.AGENTS_TICKETS_UPDATES,
+      Event.fromObject({
+        type: EventType.INFO,
+        name: RealtimeEvents.AGENTS_TICKETS_UPDATES,
+        payload,
+      })
+    )
+  }
+
+  private static getEvents(): BroadcastableEvents[] {
+    return [BroadcastableEvents.TICKET_ANNOUNCED]
+  }
+}

--- a/apps/realtime-api/src/channels/helpdesk/handlers/index.ts
+++ b/apps/realtime-api/src/channels/helpdesk/handlers/index.ts
@@ -6,4 +6,8 @@
  */
 import { IRealtimeHandler } from '@turnly/realtime'
 
-export const helpdeskHandlers: IRealtimeHandler[] = []
+import { RealtimeForAgentsTicketsHandler } from './RealtimeForAgentsTicketsHandler'
+
+export const helpdeskHandlers: IRealtimeHandler[] = [
+  new RealtimeForAgentsTicketsHandler(),
+]


### PR DESCRIPTION
## Pull Request Overview

#### What does it do?

Create the event handler for the helpdesk, so it can listen when a ticket is announced.

#### Why is it needed?

So the agents receive an update in realtime of the tickets that are going to be attended

#### How to test it?

N/A

`I agree`

Before asking for review I...

- [x] Used this first label: `🕐 Peer Review Pending`
- [x] Have added all relevant information about my changes in this PR
- [x] Have performed a self-review of my own code
- [x] Have made sure my code follows the project's style guidelines
- [x] Have checked my code and corrected any misspellings
- [x] Have made sure my changes generate no new warnings

/cc @efraa
