### PR TITLE
feat: add find answers query, endpoint, controller and update ticket resolver

### DIFF
--- a/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/FindAnswersQuery.ts
+++ b/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/FindAnswersQuery.ts
@@ -7,11 +7,12 @@
 
 import type { Extra, Guid } from '@turnly/common'
 import type { IQuery } from '@turnly/shared'
+import { EntityTypes } from 'Answers/domain/enums/EntityType'
 
 export class FindAnswersQuery implements IQuery {
   public constructor(
     public readonly organizationId: Guid,
-    public readonly entityType: string,
+    public readonly entityType: EntityTypes,
     public readonly fieldId?: Guid,
     public readonly extra?: Extra[]
   ) {}

--- a/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/FindAnswersQuery.ts
+++ b/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/FindAnswersQuery.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+
+import type { Extra, Guid } from '@turnly/common'
+import type { IQuery } from '@turnly/shared'
+
+export class FindAnswersQuery implements IQuery {
+  public constructor(
+    public readonly organizationId: Guid,
+    public readonly entityType: string,
+    public readonly fieldId?: Guid,
+    public readonly extra?: Extra[]
+  ) {}
+}

--- a/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/FindAnswersQueryHandler.ts
+++ b/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/FindAnswersQueryHandler.ts
@@ -30,11 +30,11 @@ export class FindAnswersQueryHandler
       .equal('entityType', entityType)
 
     if (fieldId) query.equal('fieldId', fieldId)
-    if (extra) {
-      extra.forEach(e => {
-        query.inExtra(e.key, e.value)
-      })
-    }
+
+    extra?.forEach(e => {
+      query.inExtra(e.key, e.value)
+    })
+
     return await this.answersReadableRepo.find(query.getMany())
   }
 }

--- a/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/FindAnswersQueryHandler.ts
+++ b/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/FindAnswersQueryHandler.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+import { Nullable } from '@turnly/common'
+import { IQueryHandler, QueryBuilder, QueryHandler } from '@turnly/shared'
+import { IAnswersReadableRepo } from 'Answers/domain/contracts/IAnswersRepo'
+import { Answer } from 'Answers/domain/entities/Answer'
+
+import { FindAnswersQuery } from './FindAnswersQuery'
+
+@QueryHandler(FindAnswersQuery)
+export class FindAnswersQueryHandler
+  implements IQueryHandler<FindAnswersQuery, Nullable<Answer[]>>
+{
+  public constructor(
+    private readonly answersReadableRepo: IAnswersReadableRepo
+  ) {}
+
+  public async execute({
+    organizationId,
+    entityType,
+    fieldId,
+    extra,
+  }: FindAnswersQuery) {
+    const query = new QueryBuilder<Answer>()
+      .equal('organizationId', organizationId)
+      .equal('entityType', entityType)
+
+    if (fieldId) query.equal('fieldId', fieldId)
+    if (extra) {
+      extra.forEach(e => {
+        query.inExtra(e.key, e.value)
+      })
+    }
+    return await this.answersReadableRepo.find(query.getMany())
+  }
+}

--- a/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/index.ts
+++ b/apps/custom-fields/src/Answers/application/queries/FindAnswersQuery/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+export * from './FindAnswersQuery'
+export * from './FindAnswersQueryHandler'

--- a/apps/custom-fields/src/Answers/domain/entities/Answer.ts
+++ b/apps/custom-fields/src/Answers/domain/entities/Answer.ts
@@ -7,6 +7,7 @@
 import { Extra, Guid, Identifier, Nullable } from '@turnly/common'
 import { AggregateRoot, EntityAttributes } from '@turnly/shared'
 
+import { EntityTypes } from '../enums/EntityType'
 import { AnswerCreatedEvent } from '../events/AnswerCreatedEvent'
 
 /**
@@ -51,7 +52,7 @@ export class Answer extends AggregateRoot {
      *
      * @description The entity type that the Answer is associated with.
      */
-    private readonly entityType: string,
+    private readonly entityType: EntityTypes,
 
     /**
      * Organization

--- a/apps/custom-fields/src/Answers/domain/enums/EntityType.ts
+++ b/apps/custom-fields/src/Answers/domain/enums/EntityType.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+/**
+ * Entity types
+ *
+ * @description Enum of the different types of entity that can be associated with a custom field answer.
+ */
+export enum EntityTypes {
+  TICKET = 'ticket',
+  CUSTOMER = 'customer',
+}

--- a/apps/custom-fields/src/Answers/infrastructure/api/controllers/AnswersController.ts
+++ b/apps/custom-fields/src/Answers/infrastructure/api/controllers/AnswersController.ts
@@ -4,20 +4,26 @@
  *
  * Licensed under BSD 3-Clause License. See LICENSE for terms.
  */
+import { Nullable, ResourceNotFoundException } from '@turnly/common'
 import {
   Controller,
   EntityAttributes,
   ICommandBus,
   InputValidator,
+  IQueryBus,
   TimeoutHandler,
 } from '@turnly/shared'
 import { CreateAnswersBulkCommand } from 'Answers/application/commands/CreateAnswerBulkCommand'
+import { FindAnswersQuery } from 'Answers/application/queries/FindAnswersQuery'
 import { Answer } from 'Answers/domain/entities/Answer'
 
 import { validator } from '../validators/AnswersValidator'
 
 export class AnswersController extends Controller {
-  public constructor(private readonly commandBus: ICommandBus) {
+  public constructor(
+    private readonly commandBus: ICommandBus,
+    private readonly queryBus: IQueryBus
+  ) {
     super()
   }
 
@@ -30,5 +36,22 @@ export class AnswersController extends Controller {
     >(new CreateAnswersBulkCommand(params))
 
     return this.respond.created(answers.map(answer => answer.toObject()))
+  }
+
+  @TimeoutHandler()
+  @InputValidator(validator.find)
+  public async find(params: FindAnswersQuery) {
+    const answers = await this.queryBus.ask<Nullable<Answer[]>>(
+      new FindAnswersQuery(
+        params.organizationId,
+        params.entityType,
+        params.fieldId,
+        params.extra
+      )
+    )
+
+    if (!answers?.length) throw new ResourceNotFoundException()
+
+    return this.respond.ok(answers.map(answer => answer.toObject()))
   }
 }

--- a/apps/custom-fields/src/Answers/infrastructure/api/rpc/AnswersServer.ts
+++ b/apps/custom-fields/src/Answers/infrastructure/api/rpc/AnswersServer.ts
@@ -4,6 +4,7 @@
  *
  * Licensed under BSD 3-Clause License. See LICENSE for terms.
  */
+import { ResourceNotFoundException } from '@turnly/common'
 import { Producers } from '@turnly/rpc'
 import { Client } from '@turnly/rpc/dist/consumers'
 
@@ -44,9 +45,36 @@ export class AnswersServer extends Producers.ServerImplementation<Producers.Cust
     callback(null, response)
   }
 
+  @Producers.CallHandler(Producers.CustomFields.FindAnswersResponse)
+  public async find(
+    call: Producers.ServerUnaryCall<
+      Producers.CustomFields.FindAnswersRequest,
+      Producers.CustomFields.FindAnswersResponse
+    >,
+    callback: Producers.ICallback<Producers.CustomFields.FindAnswersResponse>
+  ) {
+    const { data, meta } = await this.answersController.find({
+      entityType: call.request.getEntityType(),
+      fieldId: call.request.getFieldId(),
+      extra: call.request.getExtrasList().map(e => e.toObject()),
+      organizationId: Client.getOrganizationId(call),
+    })
+
+    const response = new Producers.CustomFields.FindAnswersResponse()
+    const answers = data?.map(answer => AnswersMapper.toRPC(answer))
+
+    if (!answers?.length) throw new ResourceNotFoundException()
+
+    response.setDataList(answers)
+    response.setMeta(Producers.MetaMapper.toRPC(meta))
+
+    callback(null, response)
+  }
+
   public get implementation() {
     return {
       create: this.create.bind(this),
+      find: this.find.bind(this),
     }
   }
 }

--- a/apps/custom-fields/src/Answers/infrastructure/api/rpc/AnswersServer.ts
+++ b/apps/custom-fields/src/Answers/infrastructure/api/rpc/AnswersServer.ts
@@ -7,6 +7,7 @@
 import { ResourceNotFoundException } from '@turnly/common'
 import { Producers } from '@turnly/rpc'
 import { Client } from '@turnly/rpc/dist/consumers'
+import { EntityTypes } from 'Answers/domain/enums/EntityType'
 
 import { AnswersController } from '../controllers/AnswersController'
 import { AnswersMapper } from './AnswersMapper'
@@ -29,6 +30,7 @@ export class AnswersServer extends Producers.ServerImplementation<Producers.Cust
 
       return {
         ...data,
+        entityType: answer.getEntityType() as EntityTypes,
         extra,
         organizationId: Client.getOrganizationId(call),
       }
@@ -54,7 +56,7 @@ export class AnswersServer extends Producers.ServerImplementation<Producers.Cust
     callback: Producers.ICallback<Producers.CustomFields.FindAnswersResponse>
   ) {
     const { data, meta } = await this.answersController.find({
-      entityType: call.request.getEntityType(),
+      entityType: call.request.getEntityType() as EntityTypes,
       fieldId: call.request.getFieldId(),
       extra: call.request.getExtrasList().map(e => e.toObject()),
       organizationId: Client.getOrganizationId(call),

--- a/apps/custom-fields/src/Answers/infrastructure/api/validators/AnswersValidator.ts
+++ b/apps/custom-fields/src/Answers/infrastructure/api/validators/AnswersValidator.ts
@@ -22,6 +22,13 @@ const answer = Validator.object({
 
 const create = Validator.getBuilder().array().items(answer).min(1).required()
 
+const find = Validator.object({
+  entityType: Validator.string(),
+  organizationId: Validator.isId(),
+  fieldId: Validator.isId(true),
+  extra: Validator.getBuilder().array().items(extra).optional(),
+})
 export const validator = {
   create,
+  find,
 }

--- a/apps/custom-fields/src/Answers/infrastructure/factories/AnswersFactory.ts
+++ b/apps/custom-fields/src/Answers/infrastructure/factories/AnswersFactory.ts
@@ -13,6 +13,7 @@ import {
   IWritableRepository,
 } from '@turnly/shared'
 import { CreateAnswerBulkCommandHandler } from 'Answers/application/commands/CreateAnswerBulkCommand'
+import { FindAnswersQueryHandler } from 'Answers/application/queries/FindAnswersQuery'
 import { Answer } from 'Answers/domain/entities/Answer'
 
 import { AnswersController } from '../api/controllers/AnswersController'
@@ -25,7 +26,7 @@ export class AnswersFactory {
   }
 
   public static getQueryHandlers(): IQueryHandler[] {
-    return []
+    return [Box.resolve<FindAnswersQueryHandler>('findAnswersQueryHandler')]
   }
 
   public static getWritableRepo(): IWritableRepository<Answer> {

--- a/apps/custom-fields/src/Answers/infrastructure/persistence/mongo/models/AnswerModel.ts
+++ b/apps/custom-fields/src/Answers/infrastructure/persistence/mongo/models/AnswerModel.ts
@@ -6,6 +6,7 @@
  */
 import { EntityAttributes, timestamps } from '@turnly/shared'
 import { Answer } from 'Answers/domain/entities/Answer'
+import { EntityTypes } from 'Answers/domain/enums/EntityType'
 import mongoose, { Document, Model, Schema } from 'mongoose'
 
 export interface AnswerDocument
@@ -30,7 +31,7 @@ const schema = new Schema(
       required: true,
     },
     entityType: {
-      type: String,
+      type: EntityTypes,
       required: true,
     },
     organizationId: {

--- a/apps/custom-fields/src/Answers/infrastructure/register-dependencies/dependencies.ts
+++ b/apps/custom-fields/src/Answers/infrastructure/register-dependencies/dependencies.ts
@@ -6,6 +6,7 @@
  */
 import { Box, ioc } from '@turnly/shared'
 import { CreateAnswerBulkCommandHandler } from 'Answers/application/commands/CreateAnswerBulkCommand'
+import { FindAnswersQueryHandler } from 'Answers/application/queries/FindAnswersQuery'
 
 import { AnswersController } from '../api/controllers/AnswersController'
 import { AnswersMapper } from '../persistence/mongo/entity-model-mappers/AnswersMapper'
@@ -26,4 +27,11 @@ Box.register({
   createAnswerBulkCommandHandler: ioc
     .asClass(CreateAnswerBulkCommandHandler)
     .singleton(),
+})
+
+/**
+ * Query handlers
+ */
+Box.register({
+  findAnswersQueryHandler: ioc.asClass(FindAnswersQueryHandler).singleton(),
 })

--- a/apps/custom-fields/tests/unit/Answers/__mocks__/AnswersReadableRepo.ts
+++ b/apps/custom-fields/tests/unit/Answers/__mocks__/AnswersReadableRepo.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+import { IReadableRepository } from '@turnly/shared'
+import { TestReadableRepo } from '@turnly/testing'
+import { Answer } from 'Answers/domain/entities/Answer'
+
+export class AnswersReadableRepo
+  extends TestReadableRepo<Answer>
+  implements IReadableRepository<Answer> {}

--- a/apps/custom-fields/tests/unit/Answers/application/queries/FindAnswersQuery/FindAnswersQueryHandler.test.ts
+++ b/apps/custom-fields/tests/unit/Answers/application/queries/FindAnswersQuery/FindAnswersQueryHandler.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+import { ObjectMother } from '@turnly/testing'
+
+import { FindAnswersQueryHandler } from '../../../../../../src/Answers/application/queries/FindAnswersQuery'
+import { AnswersReadableRepo } from '../../../__mocks__/AnswersReadableRepo'
+import { AnswerMother } from '../../../domain/AnswerMother'
+import { FindAnswersQueryMother } from './FindAnswersQueryMother'
+
+let repository: AnswersReadableRepo
+let handler: FindAnswersQueryHandler
+
+describe('answers > queries > validates the expected behavior of FindAnswersQuery', () => {
+  beforeEach(() => {
+    repository = new AnswersReadableRepo()
+    handler = new FindAnswersQueryHandler(repository)
+  })
+
+  it('should get a collection of existing answers', async () => {
+    const query = FindAnswersQueryMother.random()
+
+    const expected = ObjectMother.repeater(
+      AnswerMother.random,
+      ObjectMother.integer(1)
+    )
+
+    repository.attachFindResponse(expected)
+
+    const response = await handler.execute(query)
+
+    expect(response).toEqual(expected)
+    repository.assertFindHasBeenCalled()
+  })
+})

--- a/apps/custom-fields/tests/unit/Answers/application/queries/FindAnswersQuery/FindAnswersQueryMother.ts
+++ b/apps/custom-fields/tests/unit/Answers/application/queries/FindAnswersQuery/FindAnswersQueryMother.ts
@@ -6,17 +6,18 @@
  */
 import { Extra, Guid } from '@turnly/common'
 import { ObjectMother } from '@turnly/testing'
+import { EntityTypes } from 'Answers/domain/enums/EntityType'
 
 import { FindAnswersQuery } from '../../../../../../src/Answers/application/queries/FindAnswersQuery'
 
 export class FindAnswersQueryMother {
   static create(
+    entityType: EntityTypes = EntityTypes.CUSTOMER,
     fieldId: Guid = ObjectMother.uuid('field'),
-    entityType: string = ObjectMother.word(),
     extra: Extra[] = ObjectMother.repeater(ObjectMother.extra, 1),
     organizationId: Guid = ObjectMother.uuid('org')
   ): FindAnswersQuery {
-    return new FindAnswersQuery(organizationId, fieldId, entityType, extra)
+    return new FindAnswersQuery(organizationId, entityType, fieldId, extra)
   }
 
   static random(): FindAnswersQuery {

--- a/apps/custom-fields/tests/unit/Answers/application/queries/FindAnswersQuery/FindAnswersQueryMother.ts
+++ b/apps/custom-fields/tests/unit/Answers/application/queries/FindAnswersQuery/FindAnswersQueryMother.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+import { Extra, Guid } from '@turnly/common'
+import { ObjectMother } from '@turnly/testing'
+
+import { FindAnswersQuery } from '../../../../../../src/Answers/application/queries/FindAnswersQuery'
+
+export class FindAnswersQueryMother {
+  static create(
+    fieldId: Guid = ObjectMother.uuid('field'),
+    entityType: string = ObjectMother.word(),
+    extra: Extra[] = ObjectMother.repeater(ObjectMother.extra, 1),
+    organizationId: Guid = ObjectMother.uuid('org')
+  ): FindAnswersQuery {
+    return new FindAnswersQuery(organizationId, fieldId, entityType, extra)
+  }
+
+  static random(): FindAnswersQuery {
+    return this.create()
+  }
+}

--- a/apps/custom-fields/tests/unit/Answers/domain/AnswerMother.ts
+++ b/apps/custom-fields/tests/unit/Answers/domain/AnswerMother.ts
@@ -6,6 +6,7 @@
  */
 import { Extra, Guid, Nullable } from '@turnly/common'
 import { ObjectMother } from '@turnly/testing'
+import { EntityTypes } from 'Answers/domain/enums/EntityType'
 
 import { Answer } from '../../../../src/Answers/domain/entities/Answer'
 
@@ -14,7 +15,7 @@ export class AnswerMother {
     value: string = ObjectMother.names(),
     fieldId: string = ObjectMother.word(),
     entityId: string = ObjectMother.word(),
-    entityType: string = ObjectMother.word(),
+    entityType: EntityTypes = EntityTypes.CUSTOMER,
     organizationId: Guid = ObjectMother.uuid('org'),
     extra: Nullable<Extra[]> = []
   ): Answer {
@@ -40,7 +41,7 @@ export class AnswerMother {
     value: string = ObjectMother.names(),
     fieldId: string = ObjectMother.word(),
     entityId: string = ObjectMother.word(),
-    entityType: string = ObjectMother.word(),
+    entityType: EntityTypes = EntityTypes.CUSTOMER,
     organizationId: Guid = ObjectMother.uuid('org'),
     extra: Nullable<Extra[]> = [ObjectMother.extra(), ObjectMother.extra()]
   ) {

--- a/apps/helpdesk-api/src/datasources/AnswersDataSource.ts
+++ b/apps/helpdesk-api/src/datasources/AnswersDataSource.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+import { Extra, Guid } from '@turnly/common'
+import { AnswerModel } from 'models/AnswerModel'
+import { CacheTTL } from 'shared/CacheTTL'
+
+import { Answers } from '../shared/api'
+import { CacheSource } from './common/CacheSource'
+import { DataSource } from './common/DataSource'
+
+type FindAnswerParams = {
+  entityType: string
+  fieldId?: Guid
+  extra?: Extra[]
+}
+
+@CacheSource({ ttl: CacheTTL.THREE_MINUTES })
+export class AnswersDataSource extends DataSource {
+  public constructor() {
+    super()
+  }
+
+  public async findAnswers({
+    entityType,
+    fieldId = '',
+    extra = [],
+  }: FindAnswerParams): Promise<AnswerModel[]> {
+    const data = (
+      await Answers.find({
+        entityType,
+        fieldId,
+        extrasList: extra,
+      })
+    ).dataList
+
+    if (!data) return []
+
+    return data.map(({ id, value, fieldId }) => ({
+      id,
+      value,
+      fieldId,
+    }))
+  }
+}

--- a/apps/helpdesk-api/src/datasources/createSources.ts
+++ b/apps/helpdesk-api/src/datasources/createSources.ts
@@ -5,6 +5,7 @@
  * Licensed under BSD 3-Clause License. See LICENSE for terms.
  */
 import {
+  AnswersDataSource,
   CustomersDataSource,
   FieldsDataSource,
   IntegrationsDataSource,
@@ -22,4 +23,5 @@ export const createSources = () => ({
   integrations: new IntegrationsDataSource(),
   services: new ServicesDataSource(),
   tickets: new TicketsDataSource(),
+  answers: new AnswersDataSource(),
 })

--- a/apps/helpdesk-api/src/datasources/index.ts
+++ b/apps/helpdesk-api/src/datasources/index.ts
@@ -5,6 +5,7 @@
  * Licensed under BSD 3-Clause License. See LICENSE for terms.
  */
 export * from '../shared/api'
+export * from './AnswersDataSource'
 export * from './common/CacheSource'
 export * from './common/DataSource'
 export * from './createSources'

--- a/apps/helpdesk-api/src/mappers/TicketsMapper.ts
+++ b/apps/helpdesk-api/src/mappers/TicketsMapper.ts
@@ -12,7 +12,12 @@ export class TicketsMapper {
     ticket: T.AsObject
   ): Omit<
     TicketModel,
-    'customer' | 'location' | 'service' | 'calledToDesk' | 'beforeYours'
+    | 'customer'
+    | 'location'
+    | 'service'
+    | 'calledToDesk'
+    | 'beforeYours'
+    | 'answers'
   > {
     return {
       id: ticket.id,

--- a/apps/helpdesk-api/src/models/AnswerModel.ts
+++ b/apps/helpdesk-api/src/models/AnswerModel.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2022, Turnly (https://turnly.app)
+ * All rights reserved.
+ *
+ * Licensed under BSD 3-Clause License. See LICENSE for terms.
+ */
+import { Field, ID, ObjectType } from 'type-graphql'
+
+@ObjectType()
+export class AnswerModel {
+  @Field(() => ID)
+  id: string
+
+  @Field(() => String)
+  value: string
+
+  @Field(() => ID)
+  fieldId: string
+}

--- a/apps/helpdesk-api/src/models/TicketModel.ts
+++ b/apps/helpdesk-api/src/models/TicketModel.ts
@@ -6,6 +6,7 @@
  */
 import { Field, ID, InputType, Int, ObjectType } from 'type-graphql'
 
+import { AnswerModel } from './AnswerModel'
 import { CustomerModel } from './CustomerModel'
 import { LocationModel } from './LocationModel'
 import { ServiceModel } from './ServiceModel'
@@ -59,6 +60,9 @@ export class TicketModel {
 
   @Field(() => ServiceModel)
   service: ServiceModel
+
+  @Field(() => [AnswerModel], { nullable: true })
+  answers: AnswerModel[]
 
   @Field(() => ID)
   locationId: string

--- a/apps/helpdesk-api/src/resolvers/TicketsResolver.ts
+++ b/apps/helpdesk-api/src/resolvers/TicketsResolver.ts
@@ -8,6 +8,7 @@ import { IContext } from '@types'
 import { Tickets } from 'datasources'
 import { Answers } from 'datasources'
 import { TicketsMapper } from 'mappers/TicketsMapper'
+import { AnswerModel } from 'models/AnswerModel'
 import { CustomerModel } from 'models/CustomerModel'
 import { LocationModel } from 'models/LocationModel'
 import { ServiceModel } from 'models/ServiceModel'
@@ -133,6 +134,17 @@ export class TicketsResolver {
     @Ctx() { dataSources }: IContext
   ) {
     return await dataSources.tickets.getDetails(id)
+  }
+
+  @FieldResolver(() => AnswerModel)
+  public async answers(
+    @Root() ticket: TicketModel,
+    @Ctx() { dataSources }: IContext
+  ) {
+    return await dataSources.answers.findAnswers({
+      entityType: 'customer',
+      extra: [{ key: 'ticketId', value: ticket.id }],
+    })
   }
 
   @FieldResolver(() => ServiceModel)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,7 +3033,7 @@
 
 "@turnly/rpc@github:turnly/rpc.git#latest":
   version "1.0.0"
-  resolved "https://codeload.github.com/turnly/rpc/tar.gz/afedcd559e9cb500b5fcbfb53993d14de30f1924"
+  resolved "https://codeload.github.com/turnly/rpc/tar.gz/6301ff4ad119e78be5aa07de19fdefb36fb1e139"
   dependencies:
     "@grpc/grpc-js" "^1.6.7"
     google-protobuf "^3.20.1"
@@ -3268,9 +3268,9 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*", "@types/node@>=10.0.0", "@types/node@>=12", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^18.6.3":
-  version "18.11.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.14.tgz#a8571b25f3a31e9ded14e3ab9488509adef831d8"
-  integrity sha512-0KXV57tENYmmJMl+FekeW9V3O/rlcqGQQJ/hNh9r8pKIj304pskWuEd8fCyNT86g/TpO0gcOTiLzsHLEURFMIQ==
+  version "18.11.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.15.tgz#de0e1fbd2b22b962d45971431e2ae696643d3f5d"
+  integrity sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==
 
 "@types/node@^10.1.0":
   version "10.17.60"
@@ -3288,9 +3288,9 @@
   integrity sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==
 
 "@types/node@^16.10.2":
-  version "16.18.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.8.tgz#ffb2a4efa4eb4384811081776c52b054481cca54"
-  integrity sha512-TrpoNiaPvBH5h8rQQenMtVsJXtGsVBRJrcp2Ik6oEt99jHfGvDLh20VTTq3ixTbjYujukYz1IlY4N8a8yfY0jA==
+  version "16.18.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.9.tgz#47c491cfbc10460571d766c16526748fa9ad96a1"
+  integrity sha512-nhrqXYxiQ+5B/tPorWum37VgAiefi/wmfJ1QZKGKKecC8/3HqcTTJD0O+VABSPwtseMMF7NCPVT9uGgwn0YqsQ==
 
 "@types/node@^17.0.30":
   version "17.0.45"


### PR DESCRIPTION
## Pull Request Overview

#### What does it do?

Update the yarn lock file

Adds the find answers query to the custom-fields micro-service, with the endpoint in the rpc server, the controller and validator.  With the unit tests needed for the query.

Update the helpdesk-api to add the answers data source, create the answer model and update the ticket resolver to add answers to get ticket details.

#### Why is it needed?

To show the answers value in the helpdesk-api, when the agent receives a ticket detail.

#### How to test it?

<!-- *Provide information about the environment and the path to verify the behavior* -->

`Scenario 1:` Run unit tests

1. Go to custom-fields unit tests folder
2. In the readme, copy the line that runs the unit tests
3. Paste it in the console and run it

**Result**: It should run the tests and pass it without problems

`I agree`

Before asking for review I...

- [x] Used this first label: `🕐 Peer Review Pending`
- [x] Have added all relevant information about my changes in this PR
- [x] Have performed a self-review of my own code
- [x] Have made sure my code follows the project's style guidelines
- [x] Have checked my code and corrected any misspellings
- [x] Have made sure my changes generate no new warnings

/cc @efraa
